### PR TITLE
Automatic firing correct action via REQUEST_METHOD

### DIFF
--- a/classes/KO7/Controller/REST.php
+++ b/classes/KO7/Controller/REST.php
@@ -63,18 +63,16 @@ abstract class KO7_Controller_REST extends Controller {
     {
         $this->_overwrite_method();
         $method = $this->request->method();
-        $action_requested = $this->request->action();
-        if (! $action_requested)
+
+        if (! isset($this->_action_map[$method]))
         {
-            if (! isset($this->_action_map[$method]))
-            {
-                $this->request->action('invalid');
-            }
-            else
-            {
-                $this->request->action($this->_action_map[$method]);
-            }
+            $this->request->action('invalid');
         }
+        else
+        {
+            $this->request->action($this->_action_map[$method]);
+        }
+
         $this->_init_params();
 
         // Get output format from route file extension.


### PR DESCRIPTION
It did not autorecognize the request method and didn't fire the correct action.